### PR TITLE
Some fixes from the renaming and immutable dtype PRs.

### DIFF
--- a/skillmodels/estimation/skill_model.py
+++ b/skillmodels/estimation/skill_model.py
@@ -1096,7 +1096,7 @@ class SkillModel:
         title = title_text(base_title, periods=periods, stages=stages, factors="all")
 
         if write_tex is True:
-            with open(save_path, "mixture_weight") as t:
+            with open(save_path, "w") as t:
                 t.write(df_to_tex_table(df, title))
 
         return df
@@ -1117,7 +1117,7 @@ class SkillModel:
         included = self.included_factors[ind]
 
         y_var = "{}_{}".format(factor, "t_plusone")
-        x_vars = ["{}_{}".format(var, "t") for var in included + controls]
+        x_vars = ["{}_{}".format(var, "t") for var in list(included) + list(controls)]
 
         formula = y_var + " ~ " + " + ".join(x_vars)
 
@@ -1258,7 +1258,7 @@ class SkillModel:
 
         base_name = f"visualization_of_{self.model_name}.tex"
 
-        with open(join(save_path, base_name), "mixture_weight") as t:
+        with open(join(save_path, base_name), "w") as t:
             t.write(preamble + "\n\n\n")
             t.write(title)
             t.write(maketitle)

--- a/skillmodels/pre_processing/constraints.py
+++ b/skillmodels/pre_processing/constraints.py
@@ -89,7 +89,7 @@ def _invariant_meas_system_constraints(update_info, controls, factors):
     for period, meas in update_info.index:
         if update_info.loc[(period, meas), "is_repeated"]:
             first = update_info.loc[(period, meas), "first_occurence"]
-            for cont in ["constant"] + controls[period]:
+            for cont in ["constant"] + list(controls[period]):
                 locs.append(
                     [("delta", period, meas, cont), ("delta", int(first), meas, cont)]
                 )

--- a/skillmodels/pre_processing/data_processor.py
+++ b/skillmodels/pre_processing/data_processor.py
@@ -111,13 +111,19 @@ class DataProcessor:
             periods = self.periods
 
         if factors == "all":
-            factors = self.factors
+            factors = list(self.factors)
+
+        if isinstance(factors, tuple):
+            factors = list(factors)
 
         if isinstance(periods, int) or isinstance(periods, float):
             periods = [periods]
 
         if isinstance(factors, str):
             factors = [factors]
+
+        if isinstance(periods, tuple):
+            periods = list(periods)
 
         if len(other_vars) == 0 or isinstance(other_vars[0], str):
             other_vars = [other_vars] * len(periods)
@@ -162,10 +168,16 @@ class DataProcessor:
             periods = self.periods
 
         if factors == "all":
-            factors = self.factors
+            factors = list(self.factors)
+
+        if isinstance(factors, tuple):
+            factors = list(factors)
 
         if isinstance(periods, int) or isinstance(periods, float):
             periods = [periods]
+
+        if isinstance(periods, tuple):
+            periods = list(periods)
 
         if isinstance(factors, str):
             factors = [factors]
@@ -236,7 +248,7 @@ class DataProcessor:
         return score_df
 
     def reg_df(self, factor, period=None, stage=None, controls=None, agg_method="mean"):
-        controls = [] if controls is None else controls
+        controls = [] if controls is None else list(controls)
         assert (
             period is None or stage is None
         ), "You cannot specify a period and a stage for a score regression."


### PR DESCRIPTION
## Problem

#39 and #41 introduced some errors in the untested visualization code. 

- [x] `"w"` in `with open( ..., "w")` was renamed to "mixture_weight" using find and replace
- [x] Some parts of DataProcessor that are only needed for visualization tried to select columns with tuples of variables instead of lists of variables
- [x] In some places, we tried to concatenate tuples with + 