### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,37 @@
+---
+name: PyPI
+on: push
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    # Trusted publishing (OIDC): the publish step mints a short-lived token from
+    # PyPI instead of using a stored API token, so `id-token: write` is required.
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # hatch-vcs derives the version from git tags, so the full history
+          # (including tags) must be fetched.
+          fetch-depth: 0
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install pypa/build
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# Changes
+
+This is a record of all past skillmodels releases and what went into them in reverse
+chronological order. We follow [semantic versioning](https://semver.org/) and all
+releases are available on [PyPI](https://pypi.org/project/skillmodels/).
+
+## 0.1
+
+- Add the Antweiler–Freyberger (AF) sequential MLE and the Attanasio–Meghir–Nix (AMN)
+  estimators alongside the existing CHS Kalman filter, with a shared control-function
+  correction, a public measurement-family interface on `ModelSpec`, and the AF
+  source/destination calendar adapter.
+- Add a GitHub Action to build and publish the package to PyPI on tagged releases.


### PR DESCRIPTION
Adds release-to-PyPI automation, modeled on the `dags`/`optimagic` workflows but using **PyPI Trusted Publishing (OIDC)** instead of a stored API token.

**What this adds**
- `.github/workflows/publish-to-pypi.yml` — builds sdist + wheel on every push and publishes to PyPI on tagged releases (`if: startsWith(github.ref, 'refs/tags')`). Uses OIDC (`permissions: id-token: write`, no `password:`). `fetch-depth: 0` so hatch-vcs can read the version from git tags.
- `CHANGES.md` — release changelog.

**Already in place (no change needed)**
- Build backend `hatchling` + `hatch-vcs` with `dynamic = ["version"]` (version from git tags).
- Complete `[project]` metadata: description, README long-description, license, classifiers, keywords, authors/maintainers, URLs.
- `LICENSE` and `README.md`.

**Manual step required before the first publish**
- Configure a **Trusted Publisher** for the `skillmodels` project on PyPI (Project → Settings → Publishing): owner `OpenSourceEconomics`, repository `skillmodels`, workflow `publish-to-pypi.yml`, environment left blank. This is per-project — other OSE packages currently use API tokens, so there is nothing to inherit.

**To cut a release**
- Push a version tag, e.g. `git tag v0.1.0 && git push origin v0.1.0`. The workflow builds and uploads automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
