### PR TITLE
Silence beartype/numpy PEP 695 warning noise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,11 @@ ini_options.markers = [
   "long_running: slow tests skipped in CI (run with -m long_running)",
 ]
 ini_options.filterwarnings = [
+  # beartype 0.22.9 (latest) cannot decorate any parameterized numpy.typing.NDArray[...]
+  # hint under numpy>=2.5's PEP 695 NDArray[ScalarT] definition -- beartype.claw just
+  # warns and leaves the function unchecked (confirmed via minimal repro; no matching
+  # upstream issue found as of 2026-07-29). Remove once fixed upstream.
+  "ignore:(?s).*NumPy data type.*invalid.*:beartype.roar.BeartypeClawDecorWarning",
   "ignore::pandas.errors.PerformanceWarning",
 ]
 


### PR DESCRIPTION
## Summary
- Adds a scoped `pytest` `filterwarnings` ignore for `beartype.roar.BeartypeClawDecorWarning` messages about numpy dtypes. `beartype` 0.22.9 (latest release) cannot decorate any parameterized `numpy.typing.NDArray[...]` hint under `numpy>=2.5`'s PEP 695 `NDArray[ScalarT]` definition — confirmed with a minimal repro (even a bare `NDArray[np.float64]` fails). `beartype.claw` already degrades gracefully (warns, leaves that function's args unchecked) so this is log noise only, not a correctness issue. No matching upstream `beartype` issue found; will be filed separately. The filter is scoped by message so an unrelated future claw-decoration warning would still surface.

(Note: this branch is based on current `main`, which already includes the `codecov.yml` project-target bump to 95% from #96 — that commit landed on `main` before #96 was merged, so it's not repeated here.)

## Test plan
- [x] Confirmed the warning disappears: `pixi run -e tests-cpu pytest tests/test_simulate_data.py -q -rw` → 13 passed, 1 unrelated warning (previously 6 distinct `BeartypeClawDecorWarning`s)
- [x] `prek run --all-files` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)